### PR TITLE
feat: WebSocket connect & disconnect

### DIFF
--- a/build/function/Dockerfile
+++ b/build/function/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.20 as builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o main cmd/function/main.go
+
+FROM --platform=linux/amd64 public.ecr.aws/lambda/provided:al2
+
+COPY --from=builder /src/main ./main
+
+ENTRYPOINT [ "./main" ]

--- a/cmd/function/main.go
+++ b/cmd/function/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type Request = events.APIGatewayWebsocketProxyRequest
+type Response = events.APIGatewayProxyResponse
+
+func main() {
+	lambda.Start(handler)
+}
+
+func handler(ctx context.Context, req Request) (Response, error) {
+	// リクエストのボディをパース
+	var requestBody map[string]interface{}
+	err := json.Unmarshal([]byte(req.Body), &requestBody)
+	if err != nil {
+		return Response{StatusCode: 400}, fmt.Errorf("failed to parse request body: %v", err)
+	}
+
+	// action フィールドの値に基づいて処理を分岐
+	switch action := requestBody["action"].(string); action {
+	case "$connect":
+		// $connect アクションの場合の処理
+		return handleConnect()
+	case "$disconnect":
+		// $disconnect アクションの場合の処理
+		return handleDisconnect()
+	default:
+		// 不明なアクションの場合の処理
+		return Response{StatusCode: 400}, fmt.Errorf("unknown action: %s", action)
+	}
+}
+
+// $connect アクションの処理
+func handleConnect() (Response, error) {
+	// 何か処理を行う
+	return Response{StatusCode: 200}, nil
+}
+
+// $disconnect アクションの処理
+func handleDisconnect() (Response, error) {
+	// 何か処理を行う
+	return Response{StatusCode: 200}, nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/geeeeorge/mahjong-server/internal/handler"
+	"github.com/geeeeorge/mahjong-server/internal/server"
+	"github.com/geeeeorge/mahjong-server/internal/usecase"
+	"log"
+	"net"
+	"os"
+)
+
+func main() {
+	log.Println("starting Mahjong server...")
+
+	ctx := context.Background()
+
+	if err := run(ctx); err != nil {
+		log.Printf("error starting API server: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	//
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", "localhost", 8080))
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", "localhost", err)
+	}
+
+	// usecase
+	u := usecase.Usecases{
+		Health: usecase.NewHealthUsecase(),
+	}
+
+	// handler
+	h := handler.Handlers{
+		Health: handler.NewHealthHandler(u.Health),
+	}
+
+	// server
+	s := server.NewServer(h)
+
+	log.Printf("listening on %s", ln.Addr().String())
+	return s.Run(ctx, ln)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/geeeeorge/mahjong-server
 
 go 1.20
+
+require github.com/aws/aws-lambda-go v1.46.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/geeeeorge/mahjong-server
+
+go 1.20

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/aws/aws-lambda-go v1.46.0 h1:UWVnvh2h2gecOlFhHQfIPQcD8pL/f7pVCutmFl+oXU8=
+github.com/aws/aws-lambda-go v1.46.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,0 +1,5 @@
+package handler
+
+type Handlers struct {
+	Health *HealthHandler
+}

--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -1,0 +1,24 @@
+package handler
+
+import (
+	"github.com/geeeeorge/mahjong-server/internal/usecase"
+	"net/http"
+)
+
+type HealthHandler struct {
+	u *usecase.HealthUsecase
+}
+
+func NewHealthHandler(u *usecase.HealthUsecase) *HealthHandler {
+	return &HealthHandler{
+		u: u,
+	}
+}
+
+func (h *HealthHandler) GetHealth(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	resp := h.u.RespondHealth(ctx)
+
+	respondJSON(w, r, resp)
+}

--- a/internal/handler/response.go
+++ b/internal/handler/response.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func respondJSON(w http.ResponseWriter, r *http.Request, v interface{}) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		log.Printf("encode response error: %v", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := fmt.Fprintf(w, "%s", b); err != nil {
+		log.Printf("write response error: %v", err)
+		return
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"context"
+	"github.com/geeeeorge/mahjong-server/internal/handler"
+	"net"
+	"net/http"
+	"os/signal"
+	"syscall"
+)
+
+type Server struct {
+	health *handler.HealthHandler
+}
+
+func NewServer(h handler.Handlers) *Server {
+	return &Server{
+		health: h.Health,
+	}
+}
+
+func (s *Server) Run(ctx context.Context, listener net.Listener) error {
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// TODO: websocketはactionsでhandleする
+	server := &http.Server{Handler: http.HandlerFunc(s.health.GetHealth)}
+
+	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+
+	<-ctx.Done()
+
+	if err := server.Shutdown(context.Background()); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/usecase/health.go
+++ b/internal/usecase/health.go
@@ -1,0 +1,17 @@
+package usecase
+
+import (
+	"context"
+)
+
+type HealthUsecase struct{}
+
+func NewHealthUsecase() *HealthUsecase {
+	return &HealthUsecase{}
+}
+
+func (u *HealthUsecase) RespondHealth(ctx context.Context) map[string]string {
+	return map[string]string{
+		"message": "ok",
+	}
+}

--- a/internal/usecase/usecase.go
+++ b/internal/usecase/usecase.go
@@ -1,0 +1,5 @@
+package usecase
+
+type Usecases struct {
+	Health *HealthUsecase
+}


### PR DESCRIPTION
## 概要
- httpのhealthを用意してみた
- WebSocketのconnect・disconnectができるように

## 動作確認
以下でconnectionがつながることを確認
```shell
wscat -c wss://{API-ID}.execute-api.ap-northeast-1.amazonaws.com/prd/
```

## TODO
- コンソール上で作成したECR, Lambda, APIGatewayをTerraform管理に変更
- CICD作成